### PR TITLE
Allow to run without Numba

### DIFF
--- a/scatterpy/special.py
+++ b/scatterpy/special.py
@@ -11,9 +11,13 @@ This module contains special mathematical functions used in the T-matrix
 calculations.
 """
 
-import numba as nb
 import numpy as np
 from scipy import special
+
+try:
+    import numba as nb
+except ImportError:
+    print('WARNING: Numba support is disabled in ScatterPy')
 
 
 # special mathematical functions


### PR DESCRIPTION
The Numba requirement may repel people from using ScatterPy. Please consider this simple change, which makes Numba dependence optional.